### PR TITLE
Some small_tweaks

### DIFF
--- a/src/napari_sklearn_decomposition/_widget.py
+++ b/src/napari_sklearn_decomposition/_widget.py
@@ -6,22 +6,30 @@ see: https://napari.org/plugins/stable/npe2_manifest_specification.html
 
 Replace code below according to your needs.
 """
-from qtpy.QtWidgets import QWidget, QVBoxLayout, QPushButton, QComboBox, QSpinBox
-from magicgui import magicgui, magic_factory
 import napari
-from napari import Viewer
 import numpy as np
+from magicgui import magic_factory, magicgui
+from napari import Viewer
+from qtpy.QtWidgets import QComboBox, QPushButton, QSpinBox, QVBoxLayout, QWidget
+
 
 def linearize_image(image):
     shape = image.shape
-    image_lin = image.reshape(shape[0], shape[1]*shape[2])
-    return(image_lin, shape)
+    image_lin = image.reshape(shape[0], shape[1] * shape[2])
+    return (image_lin, shape)
+
 
 def image_reshape(image, n_components, shape):
-    return(image.reshape((n_components, shape[1], shape[2])))
+    return image.reshape((n_components, shape[1], shape[2]))
+
 
 @magic_factory()
-def PCA(image: 'napari.types.ImageData', n_components: int, whiten:bool=True, svd_solver:str='auto') -> 'napari.types.ImageData':
+def PCA(
+    image: "napari.types.ImageData",
+    n_components: int = 6,
+    whiten: bool = True,
+    svd_solver: str = "auto",
+) -> "napari.types.ImageData":
     from sklearn.decomposition import PCA
 
     image, shape = linearize_image(image)
@@ -29,10 +37,13 @@ def PCA(image: 'napari.types.ImageData', n_components: int, whiten:bool=True, sv
     pca.fit(image)
     output_image = image_reshape(pca.components_, n_components, shape)
     print(output_image.shape)
-    return(output_image)
+    return output_image
+
 
 @magic_factory()
-def FastICA(image: 'napari.types.ImageData', n_components: int, whiten:bool=True) -> 'napari.types.ImageData':
+def FastICA(
+    image: "napari.types.ImageData", n_components: int = 6, whiten: bool = True
+) -> "napari.types.ImageData":
     from sklearn.decomposition import FastICA
 
     image, shape = linearize_image(image)
@@ -40,22 +51,30 @@ def FastICA(image: 'napari.types.ImageData', n_components: int, whiten:bool=True
     ica.fit(image)
     output_image = image_reshape(ica.components_, n_components, shape)
     print(output_image.shape)
-    return(output_image)
+    return output_image
+
 
 @magic_factory()
-def NMF(image: 'napari.types.ImageData', n_components: int, init:str="warn", tol:float=5e-3):
+def NMF(
+    image: "napari.types.ImageData",
+    n_components: int = 6,
+    init: str = "warn",
+    tol: float = 5e-3,
+):
     from sklearn.decomposition import NMF
+
     image, shape = linearize_image(image)
     nmf = NMF(n_components=n_components, init=init, tol=tol)
     nmf.fit(image)
     output_image = image_reshape(nmf.components_, n_components, shape)
     print(output_image.shape)
-    return(output_image)
+    return output_image
+
 
 def on_create(new_widget):
     # print('viewer = ', viewer)
-    mapping = {'PCA': PCA, 'NMF' : NMF, 'FastICA': FastICA}
-    print('new_wid', new_widget)
+    mapping = {"PCA": PCA, "NMF": NMF, "FastICA": FastICA}
+    print("new_wid", new_widget)
     # new_widget.
     @new_widget.choice.changed.connect
     def _on_choice_changed(new_choice: str):
@@ -69,17 +88,19 @@ def on_create(new_widget):
         factory = mapping[new_choice]
         chosen_widget = factory()
         print(new_widget)
-        if len(new_widget)>1:
+        if len(new_widget) > 1:
             new_widget.pop()
         new_widget.append(chosen_widget)
-    _on_choice_changed('PCA')
 
-@magic_factory(choice={'choices': ['PCA', 'NMF', 'FastICA']}, call_button=False,
-               widget_init=on_create)
-def decomposition(choice: str, viewer:Viewer):
+    _on_choice_changed("PCA")
+
+
+@magic_factory(
+    choice={"choices": ["PCA", "NMF", "FastICA"]},
+    call_button=False,
+    widget_init=on_create,
+)
+def decomposition(choice: str, viewer: Viewer):
 
     # print('viewer = ', viewer)
     pass
-
-
-

--- a/src/napari_sklearn_decomposition/_widget.py
+++ b/src/napari_sklearn_decomposition/_widget.py
@@ -7,10 +7,8 @@ see: https://napari.org/plugins/stable/npe2_manifest_specification.html
 Replace code below according to your needs.
 """
 import napari
-import numpy as np
-from magicgui import magic_factory, magicgui
+from magicgui import magic_factory
 from napari import Viewer
-from qtpy.QtWidgets import QComboBox, QPushButton, QSpinBox, QVBoxLayout, QWidget
 
 
 def linearize_image(image):
@@ -81,7 +79,8 @@ def on_create(new_widget):
 
         # do whatever you need to create the widget, or look it up from some map
         # NOTE! consider the lifetime of the widget you are looking up and adding here.
-        # you may wish to create it each time with `magicgui(some_function)` (see pattern below for tips)
+        # you may wish to create it each time with `magicgui(some_function)`
+        # (see pattern below for tips)
 
         print(new_choice)
         # or you may wish to use a `magic_factory` instead

--- a/src/napari_sklearn_decomposition/_widget.py
+++ b/src/napari_sklearn_decomposition/_widget.py
@@ -35,6 +35,8 @@ def PCA(
     pca.fit(image)
     output_image = image_reshape(pca.components_, n_components, shape)
     print(output_image.shape)
+    viewer = napari.current_viewer()
+    viewer.dims.set_point(0, 0)
     return output_image
 
 
@@ -49,6 +51,8 @@ def FastICA(
     ica.fit(image)
     output_image = image_reshape(ica.components_, n_components, shape)
     print(output_image.shape)
+    viewer = napari.current_viewer()
+    viewer.dims.set_point(0, 0)
     return output_image
 
 
@@ -66,6 +70,8 @@ def NMF(
     nmf.fit(image)
     output_image = image_reshape(nmf.components_, n_components, shape)
     print(output_image.shape)
+    viewer = napari.current_viewer()
+    viewer.dims.set_point(0, 0)
     return output_image
 
 
@@ -99,7 +105,7 @@ def on_create(new_widget):
     call_button=False,
     widget_init=on_create,
 )
-def decomposition(choice: str, viewer: Viewer):
+def decomposition(choice: str):
 
     # print('viewer = ', viewer)
     pass

--- a/src/napari_sklearn_decomposition/_widget.py
+++ b/src/napari_sklearn_decomposition/_widget.py
@@ -58,9 +58,9 @@ def FastICA(
 def NMF(
     image: "napari.types.ImageData",
     n_components: int = 6,
-    init: str = "warn",
+    init: str = "nndsvda",
     tol: float = 5e-3,
-):
+) -> "napari.types.ImageData":
     from sklearn.decomposition import NMF
 
     image, shape = linearize_image(image)

--- a/src/napari_sklearn_decomposition/_widget.py
+++ b/src/napari_sklearn_decomposition/_widget.py
@@ -8,7 +8,6 @@ Replace code below according to your needs.
 """
 import napari
 from magicgui import magic_factory
-from napari import Viewer
 
 
 def linearize_image(image):


### PR DESCRIPTION
I was reading the code and playing with the plugin to learn a bit more.
Made some small tweaks:
1. set default N_components to 6. It was zero, which made nothing happen on-run. 6 matches the example
2. Set the viewer to first slice upon output. The layer sliders are linked, so when the source is in the middle slice (200) then the output is missing.
3. cleaned up some unused imports
4. tried to fix NMF
This I failed. I noticed that when changing the mode the subsequent ones the image input was greyed out. I swapped the default from PCA to NMF and confirmed that NMF now works with defaults (I made minor tweak). But the issue remains: somehow the `image` is only passed to the default, "manual" call of `_on_choice_change`.
I tried a few things, but couldn't figure it out—sorry!