### PR TITLE
Fix image data issue when changing method

### DIFF
--- a/src/napari_sklearn_decomposition/_widget.py
+++ b/src/napari_sklearn_decomposition/_widget.py
@@ -75,7 +75,6 @@ def NMF(
 
 
 def on_create(new_widget):
-    # print('viewer = ', viewer)
     mapping = {"PCA": PCA, "NMF": NMF, "FastICA": FastICA}
     print("new_wid", new_widget)
     # new_widget.
@@ -95,7 +94,9 @@ def on_create(new_widget):
         if len(new_widget) > 1:
             new_widget.pop()
         new_widget.append(chosen_widget)
-
+        chosen_widget.reset_choices()
+        viewer = napari.current_viewer()
+        viewer.layers.events.inserted.connect(chosen_widget.reset_choices)
     _on_choice_changed("PCA")
 
 

--- a/src/napari_sklearn_decomposition/_widget.py
+++ b/src/napari_sklearn_decomposition/_widget.py
@@ -94,6 +94,8 @@ def on_create(new_widget):
         if len(new_widget) > 1:
             new_widget.pop()
         new_widget.append(chosen_widget)
+        # reset_choices from:
+        # https://github.com/pattonw/napari-affinities/blob/7d9eab9100daf607ce7351f8717bff37ad71acf0/src/napari_affinities/widget.py#L61
         chosen_widget.reset_choices()
         viewer = napari.current_viewer()
         viewer.layers.events.inserted.connect(chosen_widget.reset_choices)


### PR DESCRIPTION
Fix for Issue https://github.com/jdeschamps/napari-sklearn-decomposition/issues/4
where changing the decomposition method from the default (PCA at the moment) made the image dropdown non-functional: greyed out.
As @jdeschamps suggested the fix is to just reset_choices and connect to the event, based on: https://github.com/pattonw/napari-affinities/blob/7d9eab9100daf607ce7351f8717bff37ad71acf0/src/napari_affinities/widget.py#L61


